### PR TITLE
NERSC GitLab Example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+stages:
+  - test
+
+
+variables:
+  SCHEDULER_PARAMETERS: "-C haswell -M escori -q xfer -N1 -t 01:00:00"
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger" && $CI_COMMIT_TAG'
+    - if: '$CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "schedule"'
+      when: always
+  
+      
+example:
+  stage: test
+  tags: [cori]
+  script: 
+    - bash gitlab/example-test.bash 
+
+
+
+
+

--- a/gitlab/example-test.bash
+++ b/gitlab/example-test.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "Running at NERSC on" $NERSC_HOST
+
+echo "Contents of /global/cfs/cdirs/lsst"
+runls=$(ls /global/cfs/cdirs/lsst/)
+echo $runls
+
+exit 0
+
+


### PR DESCRIPTION
There is now a new lsstdesc/examples/mirror-desc-continuous-integration set up on NERSC GitLab (software.nersc.gov) which for now can be manually run to mirror this repo.  I should briefly write up how to do this under docs/gitlab.rst or some similar file. 

The new files in this PR set up a simple example CI which demonstrates running a script on cori.

To view things on the NERSC GitLab side - I need to add people as members.  I don't see you @stuartmcalpine in the list of users - I suspect you just need to log into software.nersc.gov using your typical NERSC credentials and you'll likely be initialized in the system so I can find you.

So two things left to do:
* Provide some doc
* demonstrate returning the status of running a job at NERSC